### PR TITLE
feat: add key type column with stats

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -16,7 +16,7 @@ jobs:
           package-name: audit-org-keys
       - uses: actions/checkout@v2
       - name: get and set semver
-        run: echo "::set-env name=SEMVER::$(echo version.txt)"
+        run: echo "::set-env name=SEMVER::$(cat version.txt)"
       - name: login into github package registry
         run: docker login "docker.pkg.github.com" -u "$GITHUB_ACTOR" -p "${{ secrets.GITHUB_TOKEN }}"
       - name: build nightly docker image


### PR DESCRIPTION
### Description

Closes #11

Here's an example:

```
+--------------------------+----------+-------------+-------------+
|       DESCRIPTION        | KEY TYPE |  # OF KEYS  | # OF USERS  |
+--------------------------+----------+-------------+-------------+
| users with keys          | DSA      | 0 (0.00%)   | 0 (0.00%)   |
+--------------------------+----------+-------------+-------------+
|                          | RSA      | 74 (98.67%) | 52 (69.33%) |
+--------------------------+----------+-------------+-------------+
|                          | ECDSA    | 0 (0.00%)   | 0 (0.00%)   |
+--------------------------+----------+-------------+-------------+
|                          | Ed25519  | 1 (1.33%)   | 1 (1.33%)   |
+--------------------------+----------+-------------+-------------+
| users without keys       |          |             | 22 (29.33%) |
+--------------------------+----------+-------------+-------------+
| users with multiple keys |          |             | 12 (16.00%) |
+--------------------------+----------+-------------+-------------+
|                             TOTAL   |     75      |     75      |
+--------------------------+----------+-------------+-------------+
```